### PR TITLE
Fix angular dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,8 +1,8 @@
 {
   "name": "angular-slugify",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "./angular-slugify.js",
   "dependencies": {
-    "angular": "1.0.7"
+    "angular": ">=1"
   }
 }


### PR DESCRIPTION
Bumps slugify version to 1.0.1 and adds correct angular dependency. I tested and it is compatible with angular up to current stable 1.2.10.

Fixes #8.