### PR TITLE
Fix strict mode

### DIFF
--- a/angular-slugify.js
+++ b/angular-slugify.js
@@ -21,9 +21,10 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-"use strict";
 
 (function() {
+    "use strict";
+
     var mod = angular.module("slugifier", []);
 
     // Unicode (non-control) characters in the Latin-1 Supplement and Latin


### PR DESCRIPTION
Hi!

Because `"user strict";` is outside of the closure, it seems to apply to everything.
I have other dependencies in my project that breaks when minified together with angular-slugify because of that.

I hope you will merge it and bump a new version soon.
Have a nice day!