### PR TITLE
removed postinstall hook requiring bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "test": "test"
   },
   "scripts": {
-    "postinstall": "bower install",
     "pretest": "npm install",
     "test": "node node_modules/.bin/karma start test/karma.conf.js",
     "test-single-run": "node node_modules/.bin/karma start test/karma.conf.js --single-run"


### PR DESCRIPTION
Hi, in a project I'm working on we don't use bower, just npm. The existing postinstall hook inside package.json forces you to have bower installed even if you don't need it.
